### PR TITLE
app/models/ticket: optimize overlapping_time()

### DIFF
--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -7,12 +7,8 @@ class Ticket < ApplicationRecord
   enum status: { neutral: 0, at_risk: 2 }
 
   def self.overlapping_time(time_range)
-    # Three possibilities: They entered while the other person was there
-    # .or they left while the other person was there
-    # .or they arrived before and left after (they were there the entire time)
-    Ticket.where(entered_at: time_range)
-          .or(Ticket.where(left_at: time_range))
-          .or(Ticket.where('entered_at <= ? AND left_at >= ?', time_range.begin, time_range.end))
+    Ticket.where('entered_at <= ? AND left_at >= ?',
+                 time_range.end, time_range.begin)
   end
 
   def self.mark_cases!(time_range, area_id)


### PR DESCRIPTION
Reduces the number of comparisons from four to just two.  The old code
was a very complicated and clumsy way to check overlap of two ranges.

Now the database could also take advantage of indexes.  Unfortunately,
there's no index (yet)...

**(Please review/test thoroughly, I did not test this!)**