### PR TITLE
Fix PATCH ticket to always return left_at from server

### DIFF
--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -14,11 +14,12 @@ class TicketsController < ApplicationController
     ticket = Ticket.find(params[:id])
 
     ticket.update!(ticket_params)
+
+    render json: ticket
   rescue ActiveRecord::RecordInvalid
     # idempotency
     # TODO: Make sure this is only idempotent for the write only once validator
-  ensure
-    render json: ticket
+    render json: Ticket.find(params[:id])
   end
 
   def risk_feed

--- a/spec/factories/ticket.rb
+++ b/spec/factories/ticket.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :ticket do
     id { Faker::Internet.uuid }
     entered_at { Faker::Time.between(from: 2.hours.ago, to: 1.hour.ago) }
-    left_at { Faker::Time.between(from: 1.hour.ago, to: Time.zone.now) }
+    left_at { Faker::Time.between(from: 1.hour.ago, to: Time.zone.now - 1.minute) }
 
     area
 

--- a/spec/requests/tickets_requests_spec.rb
+++ b/spec/requests/tickets_requests_spec.rb
@@ -20,15 +20,25 @@ RSpec.describe TicketsController do
   end
 
   context 'PATCH update' do
-    let!(:ticket) { FactoryBot.create(:ticket, :open) }
+    let(:open_ticket) { FactoryBot.create(:ticket, :open) }
+    let(:closed_ticket) { FactoryBot.create(:ticket) }
     let(:left_at) { Time.zone.now }
 
     it 'updates an existing ticket' do
-      patch ticket_path(ticket), params: { id: ticket.id, ticket: { left_at: left_at } }
+      patch ticket_path(open_ticket), params: { id: open_ticket.id, ticket: { left_at: left_at } }
 
       expect(response).to have_http_status(:ok)
       expect(JSON.parse(response.body)).not_to be_empty
-      expect(ticket.reload.left_at.iso8601).to eql(left_at.iso8601)
+      expect(open_ticket.reload.left_at.iso8601).to eql(left_at.iso8601)
+    end
+
+    it 'does not update closed tickets' do
+      patch ticket_path(closed_ticket), params: { id: closed_ticket.id, ticket: { left_at: left_at } }
+      orig_left_at = closed_ticket.left_at
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).not_to be_empty
+      expect(closed_ticket.reload.left_at.iso8601).to eql(orig_left_at.iso8601)
     end
   end
 


### PR DESCRIPTION
`PATCH /tickets/:id` should return the `left_at` time when the server autoclosed a ticket. Currently it returns the `left_at` time from the params.
I implemented it similar to how `TicketsController#create` is written.

I added support for this in https://github.com/railslove/rcvr-app/pull/25, but noticed that the client's left_at time – not the server's left_at time – was inside the response.