### PR TITLE
allow unlimited data request for the last 2 days

### DIFF
--- a/app/controllers/owners/data_requests_controller.rb
+++ b/app/controllers/owners/data_requests_controller.rb
@@ -15,12 +15,8 @@ module Owners
     end
 
     def create
-      if company.data_requests.where(accepted_at: Time.zone.now.beginning_of_day..Time.zone.now).any?
-        raise RateLimitError
-      end
-
       create_params = data_request_params.merge(
-        from: Time.zone.now - current_owner.auto_checkout_time,
+        from: Time.zone.now - 48.hours,
         to: Time.zone.now,
         accepted_at: Time.zone.now
       )

--- a/spec/requests/owners/data_requests_request_spec.rb
+++ b/spec/requests/owners/data_requests_request_spec.rb
@@ -31,33 +31,11 @@ RSpec.describe Owners::DataRequestsController do
 
         new_data_request = DataRequest.last
 
-        expect(new_data_request.from).to eq(Time.zone.now - 4.hours)
+        expect(new_data_request.from).to eq(Time.zone.now - 48.hours)
         expect(new_data_request.to).to eq(Time.zone.now)
         expect(new_data_request.accepted_at).to eq(Time.zone.now)
         expect(new_data_request.reason).to eq('for fun')
       end
-    end
-  end
-
-  context 'POST further data_request on the same day' do
-    let!(:previous_request) do
-      FactoryBot.create(:data_request,
-                        company: company,
-                        from: Time.zone.now - 4.hours,
-                        to: Time.zone.now,
-                        accepted_at: Time.zone.now)
-    end
-
-    subject do
-      -> { post owners_company_data_requests_path(company_id: company.id), params: { data_request: { reason: 'for abuse' } } }
-    end
-
-    it { is_expected.to change { DataRequest.count }.by(0) }
-
-    it 'Has the correct http status' do
-      subject.call
-
-      expect(response).to have_http_status(:too_many_requests)
     end
   end
 


### PR DESCRIPTION
On-site controls are required more often and for a longer time than the default 4 hours.