### PR TITLE
Instead of overwriting `attributes`, we overwrite `as_json`

### DIFF
--- a/app/models/concerns/api_serializable.rb
+++ b/app/models/concerns/api_serializable.rb
@@ -2,10 +2,10 @@ module ApiSerializable
   extend ActiveSupport::Concern
 
   included do
-    def as_json(options)
+    def as_json(options = nil)
       attributes = self.class.const_get(:EXPOSED_ATTRIBUTES)
 
-      super options.merge(methods: attributes, only: attributes)
+      super ({ methods: attributes, only: attributes }).merge(options || {})
     end
   end
 end

--- a/app/models/concerns/api_serializable.rb
+++ b/app/models/concerns/api_serializable.rb
@@ -2,10 +2,10 @@ module ApiSerializable
   extend ActiveSupport::Concern
 
   included do
-    def attributes
-      self.class.const_get(:EXPOSED_ATTRIBUTES).map do |attr|
-        [attr, public_send(attr)]
-      end.to_h
+    def as_json(options)
+      attributes = self.class.const_get(:EXPOSED_ATTRIBUTES)
+
+      super options.merge(methods: attributes, only: attributes)
     end
   end
 end


### PR DESCRIPTION
This means that
1. we don't change the displaying of the models in the rails console
anymore, they are just as RAILS intended
2. we should not have strange behaviour with things like papertrail
which use the attributes methods
3. The api should be literally unchanged