### PR TITLE
6 edit personal checkin data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'rqrcode'
 gem "aws-sdk-s3", require: false
 gem 'activestorage-validator'
 gem 'image_processing'
+gem 'paper_trail'
 
 # Emails
 gem 'mailgun-ruby', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,6 +267,9 @@ GEM
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     orm_adapter (0.5.0)
+    paper_trail (11.1.0)
+      activerecord (>= 5.2)
+      request_store (~> 1.1)
     pg (1.2.3)
     premailer (1.11.1)
       addressable
@@ -334,6 +337,8 @@ GEM
       ffi (~> 1.0)
     redis (4.1.4)
     remotipart (1.4.4)
+    request_store (1.5.0)
+      rack (>= 1.4)
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -431,6 +436,7 @@ DEPENDENCIES
   letter_opener
   listen (~> 3.2)
   mailgun-ruby (~> 1.2)
+  paper_trail
   pg
   premailer-rails
   puma (~> 4.1)

--- a/app/controllers/owners/data_requests_controller.rb
+++ b/app/controllers/owners/data_requests_controller.rb
@@ -4,7 +4,7 @@ module Owners
       data_request = current_owner.data_requests.find(params[:id])
 
       if data_request.accepted?
-        render json: data_request, include: { tickets: { methods: :encrypted_data } }
+        render json: data_request, include: { tickets: { methods: [:encrypted_data, :encrypted_data_change_history] } }
       else
         render json: data_request
       end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -2,6 +2,8 @@ class Ticket < ApplicationRecord
   include ApiSerializable
   include RailsAdminConfig::ForTicket
 
+  has_paper_trail on: [:update], only: [:encrypted_data]
+
   AUTO_CHECKOUT_AFTER = 4.hours
   EXPOSED_ATTRIBUTES = %i[id entered_at left_at area_id company_name area_name]
 
@@ -13,7 +15,6 @@ class Ticket < ApplicationRecord
   validates :id, write_once_only: true
   validates :entered_at, write_once_only: true
   validates :left_at, write_once_only: true
-  validates :encrypted_data, write_once_only: true
   validates :public_key, write_once_only: true
   validates :area_id, write_once_only: true
 
@@ -27,4 +28,12 @@ class Ticket < ApplicationRecord
   def schedule_auto_checkout_job
     AutoCheckoutTicketJob.set(wait: company.owner.auto_checkout_time).perform_later(id)
   end
+
+  def encrypted_data_change_history
+    self.versions.map { |version|
+      ticket = version.reify
+      ticket.encrypted_data
+    }
+  end
+
 end

--- a/db/migrate/20210318214915_create_versions.rb
+++ b/db/migrate/20210318214915_create_versions.rb
@@ -1,0 +1,36 @@
+# This migration creates the `versions` table, the only schema PT requires.
+# All other migrations PT provides are optional.
+class CreateVersions < ActiveRecord::Migration[6.0]
+
+  # The largest text column available in all supported RDBMS is
+  # 1024^3 - 1 bytes, roughly one gibibyte.  We specify a size
+  # so that MySQL will use `longtext` instead of `text`.  Otherwise,
+  # when serializing very large objects, `text` might not be big enough.
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    create_table :versions do |t|
+      t.string   :item_type, {:null=>false}
+      t.uuid   :item_id,   null: false
+      t.string   :event,     null: false
+      t.string   :whodunnit
+      t.text     :object, limit: TEXT_BYTES
+
+      # Known issue in MySQL: fractional second precision
+      # -------------------------------------------------
+      #
+      # MySQL timestamp columns do not support fractional seconds unless
+      # defined with "fractional seconds precision". MySQL users should manually
+      # add fractional seconds precision to this migration, specifically, to
+      # the `created_at` column.
+      # (https://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html)
+      #
+      # MySQL users should also upgrade to at least rails 4.2, which is the first
+      # version of ActiveRecord with support for fractional seconds in MySQL.
+      # (https://github.com/rails/rails/pull/14359)
+      #
+      t.datetime :created_at
+    end
+    add_index :versions, %i(item_type item_id)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_15_153445) do
+ActiveRecord::Schema.define(version: 2021_03_18_214915) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -107,8 +107,8 @@ ActiveRecord::Schema.define(version: 2021_03_15_153445) do
     t.datetime "block_at"
     t.bigint "frontend_id"
     t.string "api_token"
-    t.integer "auto_checkout_minutes"
     t.string "menu_alias"
+    t.integer "auto_checkout_minutes"
     t.string "phone"
     t.string "company_name"
     t.index ["confirmation_token"], name: "index_owners_on_confirmation_token", unique: true
@@ -128,6 +128,16 @@ ActiveRecord::Schema.define(version: 2021_03_15_153445) do
     t.uuid "area_id"
     t.boolean "accepted_privacy_policy"
     t.index ["area_id"], name: "index_tickets_on_area_id"
+  end
+
+  create_table "versions", force: :cascade do |t|
+    t.string "item_type", null: false
+    t.uuid "item_id", null: false
+    t.string "event", null: false
+    t.string "whodunnit"
+    t.text "object"
+    t.datetime "created_at"
+    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -107,8 +107,8 @@ ActiveRecord::Schema.define(version: 2021_03_18_214915) do
     t.datetime "block_at"
     t.bigint "frontend_id"
     t.string "api_token"
-    t.string "menu_alias"
     t.integer "auto_checkout_minutes"
+    t.string "menu_alias"
     t.string "phone"
     t.string "company_name"
     t.index ["confirmation_token"], name: "index_owners_on_confirmation_token", unique: true

--- a/spec/factories/ticket.rb
+++ b/spec/factories/ticket.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     id { Faker::Internet.uuid }
     entered_at { Faker::Time.between(from: 2.hours.ago, to: 1.hour.ago) }
     left_at { Faker::Time.between(from: 1.hour.ago, to: Time.zone.now - 1.minute) }
-
+    encrypted_data {Faker::Alphanumeric.alphanumeric}
     area
 
     trait :open do

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -71,9 +71,7 @@ RSpec.describe Ticket do
       expect(ticket.encrypted_data).to eql('abc')
       expect(ticket.encrypted_data_change_history).to_not be(nil)
       expect(ticket.encrypted_data_change_history.length).to be(1)
-      puts ticket.encrypted_data_change_history
       expect(ticket.encrypted_data_change_history.first).to eq(original)
-
     end
 
   end

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -54,4 +54,28 @@ RSpec.describe Ticket do
       expect(ticket.valid?).to be(true)
     end
   end
+
+  context "Update encrypted data" do
+
+    it "can update encrypted data and keeps versions" do
+      ticket = FactoryBot.create(:ticket, entered_at: 1.hour.ago, left_at: nil)
+
+      original = ticket.encrypted_data
+
+      expect(ticket.encrypted_data.nil?).to be(false)
+      expect(ticket.encrypted_data_change_history.length).to be(0)
+
+      ticket.encrypted_data = 'abc'
+      ticket.save
+
+      expect(ticket.encrypted_data).to eql('abc')
+      expect(ticket.encrypted_data_change_history).to_not be(nil)
+      expect(ticket.encrypted_data_change_history.length).to be(1)
+      puts ticket.encrypted_data_change_history
+      expect(ticket.encrypted_data_change_history.first).to eq(original)
+
+    end
+
+  end
+
 end

--- a/spec/requests/tickets_requests_spec.rb
+++ b/spec/requests/tickets_requests_spec.rb
@@ -47,6 +47,18 @@ RSpec.describe TicketsController do
       expect(open_ticket.reload.encrypted_data).to eql('abc')
     end
 
+    it 'keeps track of encrypted data if it is updated' do
+
+      initial_encrypted_data = open_ticket.encrypted_data
+
+      patch ticket_path(open_ticket), params: { id: open_ticket.id, ticket: { encrypted_data: 'abc' } }
+
+      patch ticket_path(open_ticket), params: { id: open_ticket.id, ticket: { encrypted_data: 'def' } }
+
+      expect(open_ticket.reload.encrypted_data_change_history).to eql([initial_encrypted_data, 'abc'])
+
+    end
+
     it 'does not update closed tickets' do
       patch ticket_path(closed_ticket), params: { id: closed_ticket.id, ticket: { left_at: left_at } }
       orig_left_at = closed_ticket.left_at

--- a/spec/requests/tickets_requests_spec.rb
+++ b/spec/requests/tickets_requests_spec.rb
@@ -39,6 +39,14 @@ RSpec.describe TicketsController do
       expect(open_ticket.reload.left_at.iso8601).to eql(left_at.iso8601)
     end
 
+    it 'updates encrypted data of an existing ticket' do
+      patch ticket_path(open_ticket), params: { id: open_ticket.id, ticket: { encrypted_data: 'abc' } }
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).not_to be_empty
+      expect(open_ticket.reload.encrypted_data).to eql('abc')
+    end
+
     it 'does not update closed tickets' do
       patch ticket_path(closed_ticket), params: { id: closed_ticket.id, ticket: { left_at: left_at } }
       orig_left_at = closed_ticket.left_at


### PR DESCRIPTION
This is the backend implementation for when a guest changes its data. 

Highlights:

1) We use papertrail to keep a record of a ticket history.

2) For this similar to active storage we needed to change the relation data type to UUID. 

3) Everything is covered by tests. 

closes https://github.com/railslove/recover-backlog/issues/6