### PR TITLE
Added dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
There are a couple of outdated gems in this repository. Dependabot would help us fix them quickly. This would lead to a couple of PRs now because we have some housekeeping to do, but after we are done it should not create more than one pr a week at most. The ruby ecosystem moves rather slow compared to npm 😉 . After we have the backend up to date we could discuss if we want to do the same for the frontend, but it would be way more noise in there.