### PR TITLE
Join affiliates with owners

### DIFF
--- a/app/models/affiliate.rb
+++ b/app/models/affiliate.rb
@@ -6,6 +6,7 @@ class Affiliate < ApplicationRecord
   EXPOSED_ATTRIBUTES = %i[name logo_link logo_url]
 
   has_one_attached :logo
+  has_many :owners
 
   validates :logo, blob: { content_type: ['image/png', 'image/jpg', 'image/jpeg'] }
 

--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -105,4 +105,9 @@ class Owner < ApplicationRecord
     # There is not trial if the trial is blank or has already been passed, else it has to be at least two days in the future
     trial_ends_at? && trial_ends_at.future? ? [trial_ends_at, 50.hours.from_now].max.to_i : nil
   end
+
+  def self.non_associated_affiliates
+    # To identify owners that have used an affiliate thats not properly registered in the affiliates table.
+    Owner.where(affiliate: nil).where.not(affiliate_code: nil)
+  end
 end

--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -9,22 +9,23 @@ class Owner < ApplicationRecord
          :confirmable, :recoverable, jwt_revocation_strategy: JwtDenylist
 
   validates :email, uniqueness: true, presence: true
-  validates :password, 
-    presence: true, 
-    length: { in: Devise.password_length }, 
-    confirmation: true, 
-    on: :create 
+  validates :password,
+    presence: true,
+    length: { in: Devise.password_length },
+    confirmation: true,
+    on: :create
 
-  validates :password, 
-    allow_nil: true, 
-    length: { in: Devise.password_length }, 
-    confirmation: true, 
+  validates :password,
+    allow_nil: true,
+    length: { in: Devise.password_length },
+    confirmation: true,
     on: :update
 
   scope :affiliate, -> { where.not(affiliate: [nil, '']).order(affiliate: :asc) }
   scope :with_stripe_data, -> { where.not(stripe_subscription_id: nil) }
 
   belongs_to :frontend
+  belongs_to :affilate
 
   has_many :companies, dependent: :destroy
   has_many :areas, through: :companies
@@ -50,7 +51,7 @@ class Owner < ApplicationRecord
 
   def affiliate_logo
     return unless affiliate
-    
+
     Affiliate.find_by(code: affiliate)&.logo_url
   end
 

--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -51,8 +51,7 @@ class Owner < ApplicationRecord
 
   def affiliate_logo
     return unless affiliate
-
-    Affiliate.find_by(code: affiliate)&.logo_url
+    affiliate.logo_url
   end
 
   def frontend_url
@@ -75,8 +74,7 @@ class Owner < ApplicationRecord
     main_price_id = ENV['STRIPE_SUBSCRIPTION_PRICE_ID']
 
     raise "ENV['STRIPE_SUBSCRIPTION_PRICE_ID'] is empty" unless main_price_id.present?
-
-    Affiliate.find_by(code: affiliate)&.stripe_price_id_monthly || main_price_id
+    affiliate.stripe_price_id_monthly || main_price_id
   end
 
   def stripe_subscription

--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -25,7 +25,7 @@ class Owner < ApplicationRecord
   scope :with_stripe_data, -> { where.not(stripe_subscription_id: nil) }
 
   belongs_to :frontend
-  belongs_to :affiliate
+  belongs_to :affiliate, optional: true
 
   has_many :companies, dependent: :destroy
   has_many :areas, through: :companies

--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -25,7 +25,7 @@ class Owner < ApplicationRecord
   scope :with_stripe_data, -> { where.not(stripe_subscription_id: nil) }
 
   belongs_to :frontend
-  belongs_to :affilate
+  belongs_to :affiliate
 
   has_many :companies, dependent: :destroy
   has_many :areas, through: :companies

--- a/db/migrate/20210514123815_change_affiliate_column_name.rb
+++ b/db/migrate/20210514123815_change_affiliate_column_name.rb
@@ -1,0 +1,5 @@
+class ChangeAffiliateColumnName < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :owners, :affiliate, :affiliate_code
+  end
+end

--- a/db/migrate/20210514131228_add_affiliate_ref_to_owners.rb
+++ b/db/migrate/20210514131228_add_affiliate_ref_to_owners.rb
@@ -1,0 +1,5 @@
+class AddAffiliateRefToOwners < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :owners, :affiliates, foreign_key: true
+  end
+end

--- a/db/migrate/20210514152111_add_affiliate_ref_to_owners.rb
+++ b/db/migrate/20210514152111_add_affiliate_ref_to_owners.rb
@@ -1,5 +1,5 @@
 class AddAffiliateRefToOwners < ActiveRecord::Migration[6.1]
   def change
-    add_reference :owners, :affiliates, foreign_key: true
+    add_reference :owners, :affiliate, foreign_key: true, type: :uuid
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_14_123815) do
+ActiveRecord::Schema.define(version: 2021_05_14_152111) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -131,6 +131,8 @@ ActiveRecord::Schema.define(version: 2021_05_14_123815) do
     t.string "street"
     t.string "zip"
     t.string "city"
+    t.uuid "affiliate_id"
+    t.index ["affiliate_id"], name: "index_owners_on_affiliate_id"
     t.index ["confirmation_token"], name: "index_owners_on_confirmation_token", unique: true
     t.index ["email"], name: "index_owners_on_email", unique: true
     t.index ["frontend_id"], name: "index_owners_on_frontend_id"
@@ -165,6 +167,7 @@ ActiveRecord::Schema.define(version: 2021_05_14_123815) do
   add_foreign_key "areas", "companies"
   add_foreign_key "companies", "owners"
   add_foreign_key "data_requests", "companies"
+  add_foreign_key "owners", "affiliates"
   add_foreign_key "owners", "frontends"
   add_foreign_key "tickets", "areas"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_05_084831) do
+ActiveRecord::Schema.define(version: 2021_05_14_123815) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -116,7 +116,7 @@ ActiveRecord::Schema.define(version: 2021_05_05_084831) do
     t.string "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
-    t.string "affiliate"
+    t.string "affiliate_code"
     t.string "stripe_customer_id"
     t.string "stripe_subscription_id"
     t.datetime "trial_ends_at"

--- a/db/scripts/join_affiliate_to_owner.rb
+++ b/db/scripts/join_affiliate_to_owner.rb
@@ -1,0 +1,7 @@
+owners_with_affiliate = Owner.all.select { |owner| owner.affiliate_code }
+
+owners_with_affiliate.each do |owner|
+  matching_affiliate = Affiliate.find_by(code: owner.affiliate_code)
+  owner.affiliate = matching_affiliate if matching_affiliate
+  owner.save!
+end

--- a/db/scripts/join_affiliate_to_owner.rb
+++ b/db/scripts/join_affiliate_to_owner.rb
@@ -2,6 +2,8 @@ owners_with_affiliate = Owner.all.select { |owner| owner.affiliate_code }
 
 owners_with_affiliate.each do |owner|
   matching_affiliate = Affiliate.find_by(code: owner.affiliate_code)
-  owner.affiliate = matching_affiliate if matching_affiliate
-  owner.save!
+  if matching_affiliate
+    owner.affiliate = matching_affiliate
+    owner.save!
+  end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,1 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,1 +1,27 @@
+Affiliate.destroy_all
+Owner.destroy_all
 
+7.times do
+  FactoryBot.create(:affiliate)
+end
+affiliates = Affiliate.all
+affiliates.each { |a| puts "#{a.name} #{a.code}" }
+
+20.times do
+  FactoryBot.create(:owner)
+end
+owners = Owner.all
+owners.each { |o| puts o.name }
+
+
+# give 9 owners an affilate
+owners_with_affiliates = owners[0..8]
+owners_with_affiliates.each do |owner|
+  owner.update!(affiliate: affiliates.sample.code)
+end
+
+# give 3 owners affiliates which are not yet entities in the db
+owners_with_other_affiliates = owners[9..11]
+owners_with_other_affiliates.each do |owner|
+  owner.update!(affiliate: affiliates.sample.code.prepend('a').chop)
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,23 +5,23 @@ Owner.destroy_all
   FactoryBot.create(:affiliate)
 end
 affiliates = Affiliate.all
-affiliates.each { |a| puts "#{a.name} #{a.code}" }
+affiliates.each { |affiliate| puts "#{affiliate.name} #{affiliate.code}" }
 
 20.times do
   FactoryBot.create(:owner)
 end
 owners = Owner.all
-owners.each { |o| puts o.name }
+owners.each { |owner| puts owner.name }
 
 
 # give 9 owners an affilate
 owners_with_affiliates = owners[0..8]
 owners_with_affiliates.each do |owner|
-  owner.update!(affiliate: affiliates.sample.code)
+  owner.update!(affiliate_code: affiliates.sample.code)
 end
 
 # give 3 owners affiliates which are not yet entities in the db
 owners_with_other_affiliates = owners[9..11]
 owners_with_other_affiliates.each do |owner|
-  owner.update!(affiliate: affiliates.sample.code.prepend('a').chop)
+  owner.update!(affiliate_code: affiliates.sample.code.prepend('a').chop)
 end


### PR DESCRIPTION
* Seeded my local db with 7 affiliates and 20 owners 
    * 9 owners get an affiliate code string in owners.affiliate column.
    * 3 owners get an affiliate code that doesn’t correspond to an affiliate instance
        * To test the hypothetical that some owners may have content in the affiliate string but that content doesn't match an instance of an affiliate.
   
* Ran migration - change column name in owners table from affiliate to affiliate_code
    * After next migration to add a foreign key, owner.affiliate would refer to both the old string in the owners table AND the newly established association to an Affiliate object, which is problematic...

* Ran migration - add foreign key affiliates to owners table.
    * Also update associations in owner.rb and affiliate.rb
        * Owner belongs to affiliate (optional: true)
        * Affiliate has_many owners
 
* Ran script to join data in tables. Used `rails runner` (this script is in /db/scripts/join_affiliate_to_owner.rb)
    * Filter Owner.where(affiliate_code == true)
    * Iterate over filtered owners
        * If the affiliate_code value corresponds to an affiliate instance (by affiliate.code)  set the Owner.affiliate to this instance of affiliate.
       
* Add class method to owner.rb to quickly identify owners that have a string in affiliate_code which doesn’t correspond to an affiliate instances.
    * Test: `Owner.non_associated_affiliates.each { |owner| puts owner.affiliate_code }` (there should be 3, each string begins with 'a' based on my seed.rb)
    
* Review models to update any code that gets an affiliate with `find_by`
    * Changes: 
        * Owner - use new association to get owner.affiliate
            * #affiliate_logo
            * #stripe_price_id

Testing was done in rails console.