### PR TITLE
add possibility to customize the name of the menu (Issue: #155) 

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,4 @@
 STRIPE_SUBSCRIPTION_PRICE_ID=test_price
 HAPPY_PDF_API_KEY=HAPPY_KEY
+DATABASE_URL=postgres://postgres:mysecretpassword@127.0.0.1:5432/rcvr_api_test
 IRIS_EPS_URL=https://localhost:5556/jsonrpc

--- a/.env.test
+++ b/.env.test
@@ -1,4 +1,3 @@
 STRIPE_SUBSCRIPTION_PRICE_ID=test_price
 HAPPY_PDF_API_KEY=HAPPY_KEY
-DATABASE_URL=postgres://postgres:mysecretpassword@127.0.0.1:5432/rcvr_api_test
 IRIS_EPS_URL=https://localhost:5556/jsonrpc

--- a/app/controllers/owners/companies_controller.rb
+++ b/app/controllers/owners/companies_controller.rb
@@ -43,7 +43,7 @@ module Owners
     private
 
     def company_params
-      params.require(:company).permit(:name, :street, :zip, :city, :menu_link, :menu_pdf, :remove_menu_pdf, :privacy_policy_link, :need_to_show_corona_test, :location_type, :cwa_link_enabled, :cwa_crypto_seed)
+      params.require(:company).permit(:name, :street, :zip, :city, :menu_link, :menu_alias, :menu_pdf, :remove_menu_pdf, :privacy_policy_link, :need_to_show_corona_test, :location_type, :cwa_link_enabled, :cwa_crypto_seed)
     end
 
     def authenticate_owner_with_api_token

--- a/app/models/area.rb
+++ b/app/models/area.rb
@@ -2,7 +2,7 @@ class Area < ApplicationRecord
   include ApiSerializable
   include RailsAdminConfig::ForArea
 
-  EXPOSED_ATTRIBUTES = %i[id name menu_link checkin_link company_id company_name company_need_to_show_corona_test company_cwa_link_enabled affiliate_logo owner_is_blocked menu_alias frontend_url public_key privacy_policy_link test_exemption].freeze
+  EXPOSED_ATTRIBUTES = %i[id name menu_link menu_alias checkin_link company_id company_name company_need_to_show_corona_test company_cwa_link_enabled affiliate_logo owner_is_blocked frontend_url public_key privacy_policy_link test_exemption].freeze
 
   belongs_to :company
   has_many :tickets, dependent: :destroy

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -5,11 +5,11 @@ class Company < ApplicationRecord
 
   enum location_type: [
     :other,
-    :retail, 
-    :food_service, 
-    :craft, 
-    :workplace, 
-    :educational_institution, 
+    :retail,
+    :food_service,
+    :craft,
+    :workplace,
+    :educational_institution,
     :public_building
   ], _prefix: 'location'
 
@@ -19,7 +19,8 @@ class Company < ApplicationRecord
     street
     zip
     city
-    menu_link 
+    menu_link
+    menu_alias
     areas
     menu_pdf_link
     privacy_policy_link
@@ -45,7 +46,7 @@ class Company < ApplicationRecord
     joins(:owner).where("coalesce(companies.zip, '') = '' and coalesce(owners.affiliate, '') = ''")
   }
 
-  delegate :menu_alias, :frontend_url, :public_key, to: :owner
+  delegate :frontend_url, :public_key, to: :owner
   delegate :affiliate_logo, to: :owner
   delegate :auto_checkout_time, to: :owner
   delegate :affiliate, to: :owner, allow_nil: true
@@ -88,7 +89,7 @@ class Company < ApplicationRecord
     "#{street}, #{zip} #{city}"
   end
 
-  def affiliate=(code) 
+  def affiliate=(code)
     self.owner.update(affiliate: code)
   end
 

--- a/app/models/concerns/rails_admin_config/for_owner.rb
+++ b/app/models/concerns/rails_admin_config/for_owner.rb
@@ -5,7 +5,7 @@ module RailsAdminConfig
     included do
       rails_admin do
         fields :id, :email, :created_at, :name, :street, :zip, :city, :companies, :affiliate, :phone, :company_name, :can_use_for_free, :trial_ends_at,
-               :block_at, :frontend, :stripe_subscription_id, :stripe_customer_id, :menu_alias
+               :block_at, :frontend, :stripe_subscription_id, :stripe_customer_id
 
         field :stripe_subscription_status do
           read_only true

--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -3,22 +3,22 @@ class Owner < ApplicationRecord
   include RailsAdminConfig::ForOwner
 
   EXPOSED_ATTRIBUTES = %i[id email name phone company_name street zip city public_key affiliate stripe_subscription_status
-                          can_use_for_free trial_ends_at frontend_url block_at menu_alias]
+                          can_use_for_free trial_ends_at frontend_url block_at]
 
   devise :database_authenticatable, :jwt_authenticatable, :registerable,
          :confirmable, :recoverable, jwt_revocation_strategy: JwtDenylist
 
   validates :email, uniqueness: true, presence: true
-  validates :password, 
-    presence: true, 
-    length: { in: Devise.password_length }, 
-    confirmation: true, 
-    on: :create 
+  validates :password,
+    presence: true,
+    length: { in: Devise.password_length },
+    confirmation: true,
+    on: :create
 
-  validates :password, 
-    allow_nil: true, 
-    length: { in: Devise.password_length }, 
-    confirmation: true, 
+  validates :password,
+    allow_nil: true,
+    length: { in: Devise.password_length },
+    confirmation: true,
     on: :update
 
   scope :affiliate, -> { where.not(affiliate: [nil, '']).order(affiliate: :asc) }
@@ -50,7 +50,7 @@ class Owner < ApplicationRecord
 
   def affiliate_logo
     return unless affiliate
-    
+
     Affiliate.find_by(code: affiliate)&.logo_url
   end
 

--- a/db/migrate/20210705084018_add_menu_name_for_company.rb
+++ b/db/migrate/20210705084018_add_menu_name_for_company.rb
@@ -1,0 +1,6 @@
+class AddMenuNameForCompany < ActiveRecord::Migration[6.1]
+  def change
+    add_column :companies, :menu_alias, :string, default: false
+    remove_column :owners, :menu_alias
+  end
+end

--- a/db/migrate/20210705084018_add_menu_name_for_company.rb
+++ b/db/migrate/20210705084018_add_menu_name_for_company.rb
@@ -1,6 +1,17 @@
 class AddMenuNameForCompany < ActiveRecord::Migration[6.1]
-  def change
+  def up
     add_column :companies, :menu_alias, :string
+    Owner.all.each do|owner|
+      owner.companies.each { |company| company.update(menu_alias: owner.menu_alias) } if owner.menu_alias
+    end
     remove_column :owners, :menu_alias
+  end
+  def down
+    add_column :owners, :menu_alias, :string
+    Owner.all.each do|owner|
+      companies_with_menu_alias = owner.companies.filter{ |company| company.menu_alias.present? }
+      owner.update(menu_alias: companies_with_menu_alias.first.menu_alias) if companies_with_menu_alias.present?
+    end
+    remove_column :companies, :menu_alias, :string
   end
 end

--- a/db/migrate/20210705084018_add_menu_name_for_company.rb
+++ b/db/migrate/20210705084018_add_menu_name_for_company.rb
@@ -1,6 +1,6 @@
 class AddMenuNameForCompany < ActiveRecord::Migration[6.1]
   def change
-    add_column :companies, :menu_alias, :string, default: false
+    add_column :companies, :menu_alias, :string
     remove_column :owners, :menu_alias
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_10_105453) do
+ActiveRecord::Schema.define(version: 2021_07_05_084018) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -76,6 +76,7 @@ ActiveRecord::Schema.define(version: 2021_06_10_105453) do
     t.integer "location_type", default: 0
     t.boolean "cwa_link_enabled", default: false
     t.string "cwa_crypto_seed"
+    t.string "menu_alias", default: "f"
     t.index ["owner_id"], name: "index_companies_on_owner_id"
   end
 
@@ -126,7 +127,6 @@ ActiveRecord::Schema.define(version: 2021_06_10_105453) do
     t.bigint "frontend_id"
     t.string "api_token"
     t.integer "auto_checkout_minutes"
-    t.string "menu_alias"
     t.string "phone"
     t.string "company_name"
     t.string "street"
@@ -148,6 +148,7 @@ ActiveRecord::Schema.define(version: 2021_06_10_105453) do
     t.string "public_key"
     t.uuid "area_id"
     t.boolean "accepted_privacy_policy"
+    t.integer "cwa_checked_in"
     t.index ["area_id"], name: "index_tickets_on_area_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -76,7 +76,7 @@ ActiveRecord::Schema.define(version: 2021_07_05_084018) do
     t.integer "location_type", default: 0
     t.boolean "cwa_link_enabled", default: false
     t.string "cwa_crypto_seed"
-    t.string "menu_alias", default: "f"
+    t.string "menu_alias"
     t.index ["owner_id"], name: "index_companies_on_owner_id"
   end
 
@@ -148,7 +148,6 @@ ActiveRecord::Schema.define(version: 2021_07_05_084018) do
     t.string "public_key"
     t.uuid "area_id"
     t.boolean "accepted_privacy_policy"
-    t.integer "cwa_checked_in"
     t.index ["area_id"], name: "index_tickets_on_area_id"
   end
 

--- a/spec/requests/owners/companies_request_spec.rb
+++ b/spec/requests/owners/companies_request_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Owners::CompaniesController do
   include_context 'api request authentication'
 
   let(:owner) { FactoryBot.create(:owner) }
- 
+
   before do
     sign_in(owner)
   end
@@ -14,7 +14,7 @@ RSpec.describe Owners::CompaniesController do
       FactoryBot.create(:company, owner: owner)
       #FactoryBot.create(:company)
 
-      get(owners_companies_path) 
+      get(owners_companies_path)
     end
 
     it 'Has the correct http status' do
@@ -34,7 +34,7 @@ RSpec.describe Owners::CompaniesController do
     end
 
     subject do
-      -> { post owners_companies_path, params: { company: {name: "Acme Inc", street: "Strasse 1", zip: "12345", city: "Exampletown", need_to_show_corona_test: 24}} }
+      -> { post owners_companies_path, params: { company: {name: "Acme Inc", street: "Strasse 1", zip: "12345", city: "Exampletown", menu_alias: "Speisekarte", need_to_show_corona_test: 24}} }
     end
 
     it "creates a new company" do
@@ -48,6 +48,7 @@ RSpec.describe Owners::CompaniesController do
       expect(company.street).to eq("Strasse 1")
       expect(company.zip).to eq("12345")
       expect(company.city).to eq("Exampletown")
+      expect(company.menu_alias).to eq("Speisekarte")
       expect(company.need_to_show_corona_test).to be(24)
     end
 

--- a/spec/requests/owners/owner_request_spec.rb
+++ b/spec/requests/owners/owner_request_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe Owners::OwnersController do
       expect(json["trial_ends_at"]).to eq(owner.trial_ends_at)
       expect(json["block_at"]).to eq(owner.block_at)
       expect(json["can_use_for_free"]).to eq(owner.can_use_for_free)
-      expect(json["menu_alias"]).to eq(owner.menu_alias)
     end
   end
 


### PR DESCRIPTION
Backendwise I added a new attribute in the companies tab for the menu alias. I noticed that there already was one for the owner but setting the menu Alias on companies was more suitable in my opinion. This attribute is also delegated to the area entity to also provide the menu name when a user is checking in 